### PR TITLE
Make parser for older perl's happy, re: "Use of ?PATTERN?" error

### DIFF
--- a/t/Intertangle/API/Gtk3/GdkX11.t
+++ b/t/Intertangle/API/Gtk3/GdkX11.t
@@ -6,7 +6,7 @@ use Renard::Incunabula::Common::Setup;
 use Intertangle::API::Gtk3;
 use Gtk3;
 
-plan Gtk3::init_check
+plan Gtk3::init_check()
 	? ( tests    => 1 )
 	: ( skip_all => 'Could not init GTK' );
 

--- a/t/Intertangle/API/Gtk3/Helper.t
+++ b/t/Intertangle/API/Gtk3/Helper.t
@@ -13,7 +13,7 @@ my $temp = Path::Tiny->tempdir;
 # Add to XDG_DATA_DIRS early so that it is available for system data dir lookup.
 $ENV{XDG_DATA_DIRS} .= join(":", "/usr/local/share", "/usr/share", $temp);
 
-plan Gtk3::init_check
+plan Gtk3::init_check()
 	? ( tests    => 2 )
 	: ( skip_all => 'Could not init GTK' );
 

--- a/t/Intertangle/API/Gtk3/Helper/Gtk3/Adjustment.t
+++ b/t/Intertangle/API/Gtk3/Helper/Gtk3/Adjustment.t
@@ -7,7 +7,7 @@ use Renard::Incunabula::Common::Setup;
 use lib 't/lib';
 
 use Gtk3;
-plan Gtk3::init_check
+plan Gtk3::init_check()
 	? ( tests    => 2 )
 	: ( skip_all => 'Could not init GTK' );
 

--- a/t/Intertangle/API/Gtk3/WindowID.t
+++ b/t/Intertangle/API/Gtk3/WindowID.t
@@ -5,7 +5,7 @@ use Test::Most;
 use Renard::Incunabula::Common::Setup;
 use Gtk3;
 
-plan Gtk3::init_check
+plan Gtk3::init_check()
 	? ( tests    => 1 )
 	: ( skip_all => 'Could not init GTK' );
 


### PR DESCRIPTION
On perl ≤ 5.20 the `?` is interpreted as the start of `?PATTERN?` and
gives the error:

  Use of ?PATTERN? without explicit operator is deprecated
